### PR TITLE
Fix for URLs with existing query string parameters

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,8 +1,11 @@
 chrome.webNavigation.onBeforeNavigate.addListener(function (obj) {
     var tabId = obj.tabId;
-    var old_query_str = "?oldIssueView=true"
-    var old_jira_url = obj.url + old_query_str
-    if (obj.url.indexOf(old_query_str) < 0) {
-        chrome.tabs.update(tabId, { url: old_jira_url });
+    var url = new URL(obj.url)
+    var params = new URLSearchParams(url.search);
+
+    if(!params.has('oldIssueView')) {
+        params.set('oldIssueView', true);
+        url.search = params.toString();
+        chrome.tabs.update(tabId, { url: url.toString() });
     }
 }, { url: [{ hostContains: 'atlassian.net', pathContains: 'browse' }] });


### PR DESCRIPTION
Hi, thanks for making this. That new Jira editor it total 💩 (though that's not to say that the old one is good!). 

Previously an existing query string is not respected. `?foo=123` becomes `?foo=123?oldIssueView=true`. This was breaking the permalink option for comments.
